### PR TITLE
fix: sécurité — dev user inaccessible en production

### DIFF
--- a/src/lib/github-auth.ts
+++ b/src/lib/github-auth.ts
@@ -3,7 +3,7 @@ import { API_URL } from "@/lib/config";
 const GITHUB_CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID || "";
 const REDIRECT_URI = `${window.location.origin}${import.meta.env.BASE_URL}`;
 
-export const DEV_MODE = !GITHUB_CLIENT_ID;
+export const DEV_MODE = import.meta.env.DEV && !GITHUB_CLIENT_ID;
 
 const DEV_USER: GitHubUser = {
   login: "dev-user",


### PR DESCRIPTION
## Problème

En production, si `VITE_GITHUB_CLIENT_ID` n'est pas injecté lors du build, `DEV_MODE = !GITHUB_CLIENT_ID` devient `true`. N'importe quel utilisateur pouvait alors se connecter en tant que `dev-user` avec le token `dev-token`.

## Fix

```diff
- export const DEV_MODE = !GITHUB_CLIENT_ID;
+ export const DEV_MODE = import.meta.env.DEV && !GITHUB_CLIENT_ID;
```

`import.meta.env.DEV` est une constante Vite remplacée par `false` au moment du build de production (`vite build`), indépendamment des variables d'environnement Railway. Le dev user est désormais **structurellement impossible** en prod.

## Test plan

- [ ] En local (`pnpm dev`) sans `VITE_GITHUB_CLIENT_ID` : le dev login fonctionne toujours
- [ ] En production : le bouton de connexion redirige vers GitHub OAuth, jamais vers dev-user

🤖 Generated with [Claude Code](https://claude.com/claude-code)