### PR TITLE
fix: purge dev-token et gestion 401 en production

### DIFF
--- a/src/lib/github-auth.ts
+++ b/src/lib/github-auth.ts
@@ -96,6 +96,12 @@ export async function getGitHubUser(token: string): Promise<GitHubUser | null> {
     return DEV_USER;
   }
 
+  // Token de dev invalide en production — purger silencieusement
+  if (token === "dev-token") {
+    localStorage.removeItem("github_token");
+    return null;
+  }
+
   try {
     const response = await fetch("https://api.github.com/user", {
       headers: {
@@ -103,6 +109,12 @@ export async function getGitHubUser(token: string): Promise<GitHubUser | null> {
         Accept: "application/vnd.github.v3+json",
       },
     });
+
+    if (response.status === 401) {
+      // Token expiré ou révoqué — déconnecter proprement
+      localStorage.removeItem("github_token");
+      return null;
+    }
 
     if (!response.ok) {
       throw new Error("Failed to fetch user info");


### PR DESCRIPTION
## Problème

Suite au fix de sécurité précédent (DEV_MODE), les utilisateurs ayant `dev-token` dans leur localStorage voyaient des erreurs 401 en cascade : `/user`, `/favorites`, `/notifications`, `/collections`, `/stream`.

## Fix

Dans `getGitHubUser` :
- Si `token === "dev-token"` hors DEV_MODE → vide localStorage silencieusement, retourne null
- Si GitHub API répond 401 (token expiré/révoqué) → vide localStorage, retourne null

Au rechargement suivant, `user` sera null et tous les hooks conditionnés à `!!user` ne feront plus de requêtes authentifiées.

## Test plan

- [ ] Ouvrir la prod avec un ancien `dev-token` en localStorage → rechargement propre, pas de 401
- [ ] Simuler un token GitHub expiré → déconnexion automatique sans erreur console
- [ ] Connexion GitHub OAuth normale non impactée

🤖 Generated with [Claude Code](https://claude.com/claude-code)