### PR TITLE
fix: handleLogin utilise DEV_MODE — plus de dev-token en prod

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { DeleteConfirmDialog } from "@/components/ui/delete-confirm-dialog";
 import {
+  DEV_MODE,
   devLogin,
   initiateGitHubLogin,
   handleGitHubCallback,
@@ -211,9 +212,7 @@ function AppInner() {
   }, []);
 
   const handleLogin = () => {
-    // Check directly — no reliance on cached module constants
-    if (!import.meta.env.VITE_GITHUB_CLIENT_ID) {
-      console.log("[DEV] Fake login activated — no VITE_GITHUB_CLIENT_ID");
+    if (DEV_MODE) {
       const fakeUser = devLogin();
       setUser(fakeUser);
       navigateTo("discover");


### PR DESCRIPTION
## Problème

`handleLogin` dans `App.tsx` testait `!import.meta.env.VITE_GITHUB_CLIENT_ID` directement. Si cette variable n'est pas injectée lors du build sur le VPS, la condition est toujours vraie → `devLogin()` est appelé en production → `dev-token` stocké dans localStorage.

## Fix

Utilise `DEV_MODE` importé de `github-auth.ts`, qui est déjà protégé par `import.meta.env.DEV` (tree-shaké à `false` par Vite en production).

```diff
- if (!import.meta.env.VITE_GITHUB_CLIENT_ID) {
+ if (DEV_MODE) {
```

## Test plan

- [ ] Cliquer "Se connecter" en prod → redirige vers GitHub OAuth (pas de dev-token)
- [ ] En local sans `VITE_GITHUB_CLIENT_ID` → dev login fonctionne toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)