### PR TITLE
fix: injecte VITE_GITHUB_CLIENT_ID au build — 404 GitHub OAuth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build frontend
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_GITHUB_CLIENT_ID: ${{ secrets.VITE_GITHUB_CLIENT_ID }}
         run: pnpm build
 
       - name: Setup SSH


### PR DESCRIPTION
## Problème

Le step "Build frontend" n'injectait pas `VITE_GITHUB_CLIENT_ID`. Au build, la variable valait `""` → l'URL OAuth devenait `https://github.com/login/oauth/authorize?client_id=&...` → GitHub renvoyait une 404.

## Fix

```diff
  env:
    VITE_API_URL: ${{ secrets.VITE_API_URL }}
+   VITE_GITHUB_CLIENT_ID: ${{ secrets.VITE_GITHUB_CLIENT_ID }}
```

## Prérequis

Le secret `VITE_GITHUB_CLIENT_ID` doit être défini dans **Settings → Secrets → Actions** du repo GitHub, dans l'environnement `Galerie Picto / production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)