### PR TITLE
fix: typage TypeScript AdminPage + build vérifié

### DIFF
--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -120,7 +120,7 @@ function UserRow({
 }) {
   const [busy, setBusy] = useState(false);
 
-  async function handle(action: () => Promise<void>) {
+  async function handle(action: () => void | Promise<void>) {
     setBusy(true);
     try {
       await action();


### PR DESCRIPTION
## Summary

• Fix erreur TypeScript dans `AdminPage.tsx` : `handle()` accepte désormais `() => void | Promise<void>`
• Build vérifié et passant

## Type

fix